### PR TITLE
fix: catch timeout exception in check url open method #6

### DIFF
--- a/src/main/java/com/movinfo/crawler/CGVCrawler.java
+++ b/src/main/java/com/movinfo/crawler/CGVCrawler.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.TimeoutException;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -60,7 +61,12 @@ public class CGVCrawler
     private boolean isCheckDateUrlOpen(LocalDate checkDate){
         WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
 
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.className("on")));
+        try {
+            wait.until(ExpectedConditions.visibilityOfElementLocated(By.className("on")));
+        } catch (TimeoutException e) {
+            return false;
+        }
+        
 
         List<WebElement> elementCurrentUrlDay = driver.findElements(By.className("on"));
 


### PR DESCRIPTION
### Description
Catch TimeoutException for Webdriver wati process in isCheckUrlOpen method

### PR Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore
- [x] Bug fix
- [ ] New feature
